### PR TITLE
Tune language around hacks

### DIFF
--- a/draft-rossi-mathinrfcs-00.md
+++ b/draft-rossi-mathinrfcs-00.md
@@ -70,6 +70,11 @@ The RFC Publication Center (RPC) is responsible for tooling and implementation d
 
 The RPC is authorized to make decisions about the representation of mathematical notation for both technical and editorial reasons in order to ensure that published RFCs meet the above policy and to provide consistency across the RFC series. The RPC must document their decisions in a public place, and all changes to tooling or implementation decisions must be widely communicated to the RFC author community using mailing lists or other means.
 
+Any requirement to use a native math format over preexisting alternatives applies only when the math format is considered sufficiently mature.
+There will be a period where the solution is being developed.
+During this time, the solution might be incomplete or it might be impractical for existing documents to adapt.
+The RPC is expected to exercise judgment on a case-by-case basis.
+
 
 # Implementation Guidance {#guidance}
 


### PR DESCRIPTION
This is a little more verbose, but it attempts to do a few things:

1. Acknowledge that there are differences for inline and block math, even for existing hacks.  Inline hacks require less strict rules, whereas block uses have no real reason to continue.
2. Expand the guidance a little to mention style guides and that the RPC is expected to produce some advice on when it allows math vs. haxx.